### PR TITLE
[#27] Use https based urls for git repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ bindings to the Rust core.
     1. Either `main` or a specific version tag e.g. `v0.1.0`
 
     ```console
-    git clone -b main git@github.com:ekxide/rmw_iceoryx2.git ~/workspace/src/rmw_iceoryx2/
+    git clone -b main https://github.com/ekxide/rmw_iceoryx2.git ~/workspace/src/rmw_iceoryx2/
     ```
 
 1. Build ROS 2 with `rmw_iceoryx2` and the demo nodes:

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -7,7 +7,7 @@ Scripts for gathering and plotting benchmark data.
 1. Set up the environment for `rmw_iceoryx2` as per [these instructions](../README.md#Setup)
 1. Clone `performance_test`
     ```console
-    git clone -b 2.3.0 git@gitlab.com:ApexAI/performance_test.git ~/workspace/src/performance_test
+    git clone -b 2.3.0 https://gitlab.com/ApexAI/performance_test.git ~/workspace/src/performance_test
     ```
 1. Patch `performance_test` to recognize `rmw_iceoryx2_cxx` as zero-copy-capable
     1. NOTE: This shall soon be merged upstream to `performance_test` for convenience

--- a/doc/release-notes/unreleased.md
+++ b/doc/release-notes/unreleased.md
@@ -30,6 +30,7 @@
 -->
 
 * Organize code base to separate rmw api and implementation details [#16](https://github.com/ekxide/rmw_iceoryx2/issues/16)
+* Use https based url for git repos [#27](https://github.com/ekxide/rmw_iceoryx2/issues/27)
 
 ### Workflow
 

--- a/iceoryx.repos
+++ b/iceoryx.repos
@@ -1,9 +1,9 @@
 repositories:
   eclipse-iceoryx/iceoryx:
     type: git
-    url: git@github.com:eclipse-iceoryx/iceoryx.git
+    url: https://github.com/eclipse-iceoryx/iceoryx.git
     version: e693cc28f64273891030a179ffc15fda155b305a
   iceoryx2:
     type: git
-    url: git@github.com:eclipse-iceoryx/iceoryx2.git
+    url: https://github.com/eclipse-iceoryx/iceoryx2.git
     version: v0.5.0


### PR DESCRIPTION
## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

The ssh based git urls can only be used by users who have a github account. This PR changes those URLs to https based urls.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Relevant issues are linked in the [References](#references) section
* [x] Every source code file has a copyright header with `SPDX-License-Identifier: Apache-2.0 OR MIT`
* [x] Branch follows the naming format (`rmw-iox2-123-implement-graph-api`)
* [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
* [x] Tests exist for new behavior
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
* [x] Assign PR to reviewer

[changelog]: https://github.com/ekxide/rmw_iceoryx2/blob/main/doc/release-notes/unreleased.md

## Checklist for the PR Reviewer

* [x] Commits are properly organized and messages are according to the guideline
* [x] Unit tests have been written for new behavior
* [x] Public API is documented
* [x] PR title describes the changes

## Post-review Checklist for the PR Author

* [x] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #27 

