### PR TITLE
[#29] Fix Ubuntu 22.04 build with GCC 11 and clang 14

### DIFF
--- a/.github/actions/install-clang/action.yml
+++ b/.github/actions/install-clang/action.yml
@@ -1,4 +1,9 @@
 name: 'Install clang'
+inputs:
+  version:
+    description: 'The clang version, e.g. 18'
+    required: false
+    default: 18
 runs:
   using: "composite"
   steps:
@@ -6,14 +11,14 @@ runs:
       shell: bash
       run: |
         sudo wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-        sudo add-apt-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-18 main"
+        sudo add-apt-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-${{ inputs.version }} main"
         sudo apt-get update
-        sudo apt-get install -y clang-format-18 clang-tidy-18 clang-tools-18 clang-18 lld
+        sudo apt-get install -y clang-format-${{ inputs.version }} clang-tidy-${{ inputs.version }} clang-tools-${{ inputs.version }} clang-${{ inputs.version }} lld
         sudo rm -f /usr/bin/clang
         sudo rm -f /usr/bin/clang++
         sudo rm -f /usr/bin/clang-tidy
         sudo rm -f /usr/bin/clang-format
-        sudo ln -s /usr/bin/clang-18 /usr/bin/clang
-        sudo ln -s /usr/bin/clang++-18 /usr/bin/clang++
-        sudo ln -s /usr/bin/clang-tidy-18 /usr/bin/clang-tidy
-        sudo ln -s /usr/bin/clang-format-18 /usr/bin/clang-format
+        sudo ln -s /usr/bin/clang-${{ inputs.version }} /usr/bin/clang
+        sudo ln -s /usr/bin/clang++-${{ inputs.version }} /usr/bin/clang++
+        sudo ln -s /usr/bin/clang-tidy-${{ inputs.version }} /usr/bin/clang-tidy
+        sudo ln -s /usr/bin/clang-format-${{ inputs.version }} /usr/bin/clang-format

--- a/.github/actions/install-gcc/action.yml
+++ b/.github/actions/install-gcc/action.yml
@@ -1,4 +1,9 @@
 name: 'Install GCC'
+inputs:
+  version:
+    description: 'The gcc version, e.g. 13'
+    required: false
+    default: 13
 runs:
   using: "composite"
   steps:
@@ -9,4 +14,8 @@ runs:
         apt-get install -y software-properties-common
         add-apt-repository -y ppa:ubuntu-toolchain-r/test
         apt-get update
-        apt-get install -y gcc-13 g++-13
+        apt-get install -y gcc-${{ inputs.version }} g++-${{ inputs.version }}
+        sudo rm -f /usr/bin/gcc
+        sudo rm -f /usr/bin/g++
+        sudo ln -s /usr/bin/gcc-${{ inputs.version }} /usr/bin/gcc
+        sudo ln -s /usr/bin/g++-${{ inputs.version }} /usr/bin/g++

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -76,6 +76,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-22.04, ubuntu-24.04]
         compiler: [clang, gcc]
         include:
           - compiler: clang
@@ -84,7 +85,7 @@ jobs:
           - compiler: gcc
             cc: gcc
             cxx: g++
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     container:
       image: ros:rolling
     steps:
@@ -179,7 +180,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test-results-${{ matrix.compiler }}
+          name: test-results-${{ matrix.os }}-${{ matrix.compiler }}
           path: |
             ${{ env.WORKSPACE_DIR }}/build/*/test_results/*/*.xml
             ${{ env.WORKSPACE_DIR }}/log/**/test*.log

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -132,10 +132,7 @@ jobs:
       - name: Import iceoryx
         run: |
           cd $WORKSPACE_DIR
-
-          # need to switch to https in ci
-          sed 's|git@github.com:|https://github.com/|g' src/rmw_iceoryx2/iceoryx.repos > _deps.repos
-          vcs import src < _deps.repos
+          vcs import src < src/rmw_iceoryx2/iceoryx.repos
 
       - name: Check compiler versions
         run: |

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -85,6 +85,12 @@ jobs:
           - compiler: gcc
             cc: gcc
             cxx: g++
+          - os: ubuntu-22.04
+            clang-version: 14
+            gcc-version: 11
+          - os: ubuntu-24.04
+            clang-version: 18
+            gcc-version: 13
     runs-on: ${{ matrix.os }}
     container:
       image: ros:rolling
@@ -125,10 +131,14 @@ jobs:
       # this is also required for all builds as iceoryx2 depends on libclang
       - name: Install clang toolchain
         uses: ./src/rmw_iceoryx2/.github/actions/install-clang
+        with:
+          version: ${{ matrix.clang-version }}
 
       - name: Install gcc toolchain
         if: matrix.compiler == 'gcc'
         uses: ./src/rmw_iceoryx2/.github/actions/install-gcc
+        with:
+          version: ${{ matrix.gcc-version }}
 
       - name: Import iceoryx
         run: |

--- a/doc/release-notes/unreleased.md
+++ b/doc/release-notes/unreleased.md
@@ -21,6 +21,7 @@
 -->
 
 * Fix failing `gcc` build [#15](https://github.com/ekxide/rmw_iceoryx2/issues/15)
+* Fix failing `gcc` and `clang` build on Ubuntu 22.04 [#29](https://github.com/ekxide/rmw_iceoryx2/issues/29)
 
 ### Refactoring
 

--- a/rmw_iceoryx2_cxx/CMakeLists.txt
+++ b/rmw_iceoryx2_cxx/CMakeLists.txt
@@ -15,6 +15,7 @@ if(NOT CMAKE_C_STANDARD)
 endif()
 
 set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   # NOTE: Remove -Wno-unused-parameter after implementation

--- a/rmw_iceoryx2_cxx/include/rmw_iceoryx2_cxx/impl/middleware/iceoryx2.hpp
+++ b/rmw_iceoryx2_cxx/include/rmw_iceoryx2_cxx/impl/middleware/iceoryx2.hpp
@@ -10,6 +10,7 @@
 #ifndef RMW_IOX2_MIDDLEWARE_ICEORYX2_HPP_
 #define RMW_IOX2_MIDDLEWARE_ICEORYX2_HPP_
 
+#include "iox/type_traits.hpp"
 #include "iox2/listener.hpp"
 #include "iox2/node.hpp"
 #include "iox2/notifier.hpp"
@@ -157,7 +158,7 @@ auto Iceoryx2::service_builder(const std::string& service_name) -> ::iox2::Servi
     } else if constexpr (S == ::iox2::ServiceType::Ipc) {
         return ipc().service_builder(name.value());
     } else {
-        static_assert(std::false_type::value, "Attempted to build a service of unknown type");
+        static_assert(iox::always_false_v<decltype(S)>, "Attempted to build a service of unknown type");
     }
 }
 

--- a/rmw_iceoryx2_cxx/include/rmw_iceoryx2_cxx/impl/runtime/publisher.hpp
+++ b/rmw_iceoryx2_cxx/include/rmw_iceoryx2_cxx/impl/runtime/publisher.hpp
@@ -51,7 +51,7 @@ private:
     using IceoryxNotifier = Iceoryx2::InterProcess::Notifier;
     using IceoryxPublisher = Iceoryx2::InterProcess::Publisher<Payload>;
     using IceoryxSample = Iceoryx2::InterProcess::SampleMutUninit<Payload>;
-    using SampleRegistry = SampleRegistry<IceoryxSample>;
+    using IceoryxSampleRegistry = SampleRegistry<IceoryxSample>;
 
 public:
     /// @brief Constructor for PublisherImpl
@@ -116,7 +116,7 @@ private:
     iox::optional<IdType> m_iox_unique_id;
     iox::optional<IceoryxNotifier> m_iox2_notifier;
     iox::optional<IceoryxPublisher> m_iox2_publisher;
-    SampleRegistry m_registry;
+    IceoryxSampleRegistry m_registry;
 };
 
 } // namespace rmw::iox2

--- a/rmw_iceoryx2_cxx/include/rmw_iceoryx2_cxx/impl/runtime/subscriber.hpp
+++ b/rmw_iceoryx2_cxx/include/rmw_iceoryx2_cxx/impl/runtime/subscriber.hpp
@@ -53,7 +53,7 @@ private:
     using IdType = ::iox2::UniqueSubscriberId;
     using IceoryxSubscriber = Iceoryx2::InterProcess::Subscriber<Payload>;
     using IceoryxSample = Iceoryx2::InterProcess::Sample<Payload>;
-    using SampleRegistry = SampleRegistry<IceoryxSample>;
+    using IceoryxSampleRegistry = SampleRegistry<IceoryxSample>;
 
 public:
     /// @brief Constructor for SubscriberImpl
@@ -105,7 +105,7 @@ private:
 
     iox::optional<IdType> m_iox2_unique_id;
     iox::optional<IceoryxSubscriber> m_iox2_subscriber;
-    SampleRegistry m_registry;
+    IceoryxSampleRegistry m_registry;
 };
 
 } // namespace rmw::iox2

--- a/rmw_iceoryx2_cxx/include/rmw_iceoryx2_cxx/impl/runtime/waitset.hpp
+++ b/rmw_iceoryx2_cxx/include/rmw_iceoryx2_cxx/impl/runtime/waitset.hpp
@@ -12,6 +12,7 @@
 
 #include "iox/duration.hpp"
 #include "iox/optional.hpp"
+#include "iox/type_traits.hpp"
 #include "rmw/visibility_control.h"
 #include "rmw_iceoryx2_cxx/impl/common/creation_lock.hpp"
 #include "rmw_iceoryx2_cxx/impl/common/error.hpp"
@@ -68,7 +69,7 @@ class RMW_PUBLIC WaitSet
         } else if constexpr (std::is_same_v<ListenerType, SubscriberListener>) {
             return Iceoryx2::ServiceType::Ipc;
         } else {
-            static_assert(std::false_type::value, "Unsupported listener type");
+            static_assert(iox::always_false_v<ListenerType>, "Unsupported listener type");
         }
     }();
 


### PR DESCRIPTION
## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

This PR  fixes build failures on Ubuntu 22.04 with GCC 11 and clang 14. Additionally, CI jobs for Ubuntu 22.04 with GCC 11 and clang 14 are added.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Relevant issues are linked in the [References](#references) section
* [x] Every source code file has a copyright header with `SPDX-License-Identifier: Apache-2.0 OR MIT`
* [x] Branch follows the naming format (`rmw-iox2-123-implement-graph-api`)
* [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
* [x] Tests exist for new behavior
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
* [x] Assign PR to reviewer

[changelog]: https://github.com/ekxide/rmw_iceoryx2/blob/main/doc/release-notes/unreleased.md

## Checklist for the PR Reviewer

* [x] Commits are properly organized and messages are according to the guideline
* [x] Unit tests have been written for new behavior
* [x] Public API is documented
* [x] PR title describes the changes

## Post-review Checklist for the PR Author

* [x] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #29 

